### PR TITLE
Use FindAllPathsOfLengthN instead of query mol.

### DIFF
--- a/stk/calculators/optimization/macromodel.py
+++ b/stk/calculators/optimization/macromodel.py
@@ -792,19 +792,13 @@ class MacroModelForceField(_MacroModel):
 
         """
 
-        # Create a substructure consisting of 3 dummy atoms bonded with
-        # 3 dummy bonds. This substructure will match with any 3 atoms
-        # which are bonded together with any combination of bonds.
-        # These 3 atoms will therefore have a bond angle.
-        ba_mol = rdkit.MolFromSmarts('[*]~[*]~[*]')
-
-        # Get the indices of all atoms which have a bond angle.
-        # ``ba_atoms`` is a tuple of tuples of the form ((1,2,3),
-        # (4,5,6), (7,8,9), ...). Each inner tuple holds the indicies
-        # of the atoms which form a bond angle.
-        ba_atoms = mol.mol.GetSubstructMatches(ba_mol)
-
-        for atom_ids in ba_atoms:
+        paths = rdkit.FindAllPathsOfLengthN(
+            mol=mol.mol,
+            length=3,
+            useBonds=False,
+            useHs=True
+        )
+        for atom_ids in paths:
             atom_ids = [i+1 for i in atom_ids]
             args = ('FXBA', *atom_ids, 99999, 0, 0, 0, 0)
             fix_block += self.com_line(*args)
@@ -833,20 +827,13 @@ class MacroModelForceField(_MacroModel):
 
         """
 
-        # Create a substructure consisting of 4 dummy atoms bonded with
-        # 4 dummy bonds. This substructure will match with any 4 atoms
-        # which are bonded together with any combination of bonds.
-        # These 4 atoms will therefore have a torsinal angle.
-        ta_mol = rdkit.MolFromSmarts('[*]~[*]~[*]~[*]')
-
-        # Get the indices of all atoms which have a torsional angle.
-        # ``ta_atoms`` as a tuple of tuples of the form ((1,2,3,4),
-        # (4,5,6,7), ...). Each inner tuple holds the indicies of the
-        # atoms which have a torsional angle.
-        ta_atoms = mol.mol.GetSubstructMatches(ta_mol)
-
-        # Apply the fix.
-        for atom_ids in ta_atoms:
+        paths = rdkit.FindAllPathsOfLengthN(
+            mol=mol.mol,
+            length=4,
+            useBonds=False,
+            useHs=True
+        )
+        for atom_ids in paths:
             atom_ids = [i+1 for i in atom_ids]
             args = ('FXTA', *atom_ids, 99999, 361, 0, 0)
             fix_block += self.com_line(*args)

--- a/stk/calculators/optimization/macromodel.py
+++ b/stk/calculators/optimization/macromodel.py
@@ -1220,19 +1220,13 @@ class MacroModelMD(_MacroModel):
 
         """
 
-        # Create a substructure consisting of 3 dummy atoms bonded with
-        # 3 dummy bonds. This substructure will match with any 3 atoms
-        # which are bonded together with any combination of bonds.
-        # These 3 atoms will therefore have a bond angle.
-        ba_mol = rdkit.MolFromSmarts('[*]~[*]~[*]')
-
-        # Get the indices of all atoms which have a bond angle.
-        # ``ba_atoms`` is a tuple of tuples of the form ((1,2,3),
-        # (4,5,6), (7,8,9), ...). Each inner tuple holds the indicies
-        # of the atoms which form a bond angle.
-        ba_atoms = mol.mol.GetSubstructMatches(ba_mol)
-
-        for atom_ids in ba_atoms:
+        paths = rdkit.FindAllPathsOfLengthN(
+            mol=mol.mol,
+            length=3,
+            useBonds=False,
+            useHs=True
+        )
+        for atom_ids in paths:
             if frozenset(atom_ids) in self.restricted_bond_angles:
                 atom_ids = [i+1 for i in atom_ids]
                 args = ('FXBA', *atom_ids, 99999, 0, 0, 0, 0)
@@ -1260,20 +1254,14 @@ class MacroModelMD(_MacroModel):
 
         """
 
-        # Create a substructure consisting of 4 dummy atoms bonded with
-        # 4 dummy bonds. This substructure will match with any 4 atoms
-        # which are bonded together with any combination of bonds.
-        # These 4 atoms will therefore have a torsinal angle.
-        ta_mol = rdkit.MolFromSmarts('[*]~[*]~[*]~[*]')
-
-        # Get the indices of all atoms which have a torsional angle.
-        # ``ta_atoms`` as a tuple of tuples of the form ((1,2,3,4),
-        # (4,5,6,7), ...). Each inner tuple holds the indicies of the
-        # atoms which have a torsional angle.
-        ta_atoms = mol.mol.GetSubstructMatches(ta_mol)
-
+        paths = rdkit.FindAllPathsOfLengthN(
+            mol=mol.mol,
+            length=4,
+            useBonds=False,
+            useHs=True
+        )
         # Apply the fix.
-        for atom_ids in ta_atoms:
+        for atom_ids in paths:
             if frozenset(atom_ids) in self.restricted_torsional_angles:
                 atom_ids = [i+1 for i in atom_ids]
                 args = ('FXTA', *atom_ids, 99999, 361, 0, 0)

--- a/tests/test_macromodel.py
+++ b/tests/test_macromodel.py
@@ -79,7 +79,8 @@ def test_unrestricted_md(tmp_cc3, macromodel_path):
                           minimum_gradient=1,
                           simulation_time=20,
                           eq_time=2,
-                          conformers=2)
+                          conformers=2,
+                          time_step=0.1)
     mm.optimize(tmp_cc3, conformer=0)
     tmp_cc3.write(join(outdir, 'umm_md_after.mol'), conformer=0)
 

--- a/tests/test_macromodel.py
+++ b/tests/test_macromodel.py
@@ -12,6 +12,7 @@ import os
 from os.path import join
 import numpy as np
 import stk
+import rdkit.Chem.AllChem as rdkit
 
 macromodel = pytest.mark.skipif(
     all('macromodel' not in x for x in sys.argv),
@@ -25,14 +26,76 @@ if not os.path.exists(outdir):
 
 @macromodel
 def test_restricted_force_field(tmp_cc3, macromodel_path):
+    bonder_ids = {
+        bid for fg in tmp_cc3.func_groups for bid in fg.bonder_ids
+    }
+
+    # Save all bond lengths, angles and torsions which are restricted.
+    dims_before = {}
+    for bond in tmp_cc3.mol.GetBonds():
+        a1, a2 = atoms = (bond.GetBeginAtomIdx(), bond.GetEndAtomIdx())
+        if a1 not in bonder_ids and a2 not in bonder_ids:
+            bond_length = tmp_cc3.atom_distance(a1, a2, conformer=0)
+            dims_before[(min(atoms), max(atoms))] = bond_length
+
+    conf = tmp_cc3.mol.GetConformer(0)
+    bond_angles = rdkit.FindAllPathsOfLengthN(
+        mol=tmp_cc3.mol,
+        length=3,
+        useBonds=False,
+        useHs=True
+    )
+    for atoms in bond_angles:
+        dims_before[tuple(atoms)] = rdkit.GetAngleDeg(conf, *atoms)
+
+    torsion_angles = rdkit.FindAllPathsOfLengthN(
+        mol=tmp_cc3.mol,
+        length=4,
+        useBonds=False,
+        useHs=True
+    )
+    for atoms in torsion_angles:
+        dims_before[tuple(atoms)] = rdkit.GetDihedralDeg(conf, *atoms)
+
     tmp_cc3.write(join(outdir, 'rmm_ff_before.mol'), conformer=0)
 
-    mm = stk.MacroModelForceField(macromodel_path=macromodel_path,
-                                  output_dir='rmm_ff',
-                                  restricted=True,
-                                  minimum_gradient=1)
+    mm = stk.MacroModelForceField(
+        macromodel_path=macromodel_path,
+        output_dir='rmm_ff',
+        restricted=True,
+        minimum_gradient=1
+    )
     mm.optimize(tmp_cc3, conformer=0)
     tmp_cc3.write(join(outdir, 'rmm_ff_after.mol'), conformer=0)
+
+    # Save all bond lengths, angles and torsions which are restricted.
+    dims_after = {}
+    for bond in tmp_cc3.mol.GetBonds():
+        a1, a2 = atoms = (bond.GetBeginAtomIdx(), bond.GetEndAtomIdx())
+        if a1 not in bonder_ids and a2 not in bonder_ids:
+            bond_length = tmp_cc3.atom_distance(a1, a2, conformer=0)
+            dims_after[(min(atoms), max(atoms))] = bond_length
+
+    conf = tmp_cc3.mol.GetConformer(0)
+    bond_angles = rdkit.FindAllPathsOfLengthN(
+        mol=tmp_cc3.mol,
+        length=3,
+        useBonds=False,
+        useHs=True
+    )
+    for atoms in bond_angles:
+        dims_after[tuple(atoms)] = rdkit.GetAngleDeg(conf, *atoms)
+
+    torsion_angles = rdkit.FindAllPathsOfLengthN(
+        mol=tmp_cc3.mol,
+        length=4,
+        useBonds=False,
+        useHs=True
+    )
+    for atoms in torsion_angles:
+        dims_after[tuple(atoms)] = rdkit.GetDihedralDeg(conf, *atoms)
+
+    assert dims_before == dims_after
 
 
 @macromodel
@@ -52,22 +115,72 @@ def test_unrestricted_force_field(tmp_cc3, macromodel_path):
 def test_restricted_md(tmp_cc3, macromodel_path):
     tmp_cc3.write(join(outdir, 'rmm_md_before.mol'), conformer=0)
 
-    # Freeze one of the bonders.
+    # Freeze all bond lengths for one of the bonders.
     bonder = tmp_cc3.func_groups[0].bonder_ids[0]
     restricted_bonds = []
     for neighbor in tmp_cc3.mol.GetAtomWithIdx(bonder).GetNeighbors():
         restricted_bonds.append(frozenset((bonder, neighbor.GetIdx())))
 
-    mm = stk.MacroModelMD(macromodel_path=macromodel_path,
-                          output_dir='rmm_md',
-                          minimum_gradient=1,
-                          simulation_time=20,
-                          eq_time=2,
-                          conformers=2,
-                          time_step=0.1,
-                          restricted_bonds=restricted_bonds)
+    # Freeze some bond angle.
+    bond_angles = rdkit.FindAllPathsOfLengthN(
+        mol=tmp_cc3.mol,
+        length=3,
+        useBonds=False,
+        useHs=True
+    )
+    restricted_bond_angles = [frozenset(bond_angles[0])]
+
+    # Freeze some torsional angle.
+    torsion_angles = rdkit.FindAllPathsOfLengthN(
+        mol=tmp_cc3.mol,
+        length=4,
+        useBonds=False,
+        useHs=True
+    )
+    restricted_torsional_angles = [frozenset(torsion_angles[0])]
+
+    # Save all bond lengths, angles and torsions which are restricted.
+    dims_before = {}
+    for atoms in restricted_bonds:
+        bond_length = tmp_cc3.atom_distance(*atoms, conformer=0)
+        dims_before[atoms] = bond_length
+
+    conf = tmp_cc3.mol.GetConformer(0)
+    for atoms in restricted_bond_angles:
+        dims_before[atoms] = rdkit.GetAngleDeg(conf, *atoms)
+
+    for atoms in restricted_torsional_angles:
+        dims_before[atoms] = rdkit.GetDihedralDeg(conf, *atoms)
+
+    mm = stk.MacroModelMD(
+        macromodel_path=macromodel_path,
+        output_dir='rmm_md',
+        minimum_gradient=1,
+        simulation_time=20,
+        eq_time=2,
+        conformers=2,
+        time_step=0.1,
+        restricted_bonds=restricted_bonds,
+        restricted_bond_angles=restricted_bond_angles,
+        restricted_torsional_angles=restricted_torsional_angles
+    )
     mm.optimize(tmp_cc3, conformer=0)
     tmp_cc3.write(join(outdir, 'rmm_md_after.mol'), conformer=0)
+
+    # Save all bond lengths, angles and torsions which are restricted.
+    dims_after = {}
+    for atoms in restricted_bonds:
+        bond_length = tmp_cc3.atom_distance(*atoms, conformer=0)
+        dims_after[atoms] = bond_length
+
+    conf = tmp_cc3.mol.GetConformer(0)
+    for atoms in restricted_bond_angles:
+        dims_after[atoms] = rdkit.GetAngleDeg(conf, *atoms)
+
+    for atoms in restricted_torsional_angles:
+        dims_after[atoms] = rdkit.GetDihedralDeg(conf, *atoms)
+
+    assert dims_before == dims_after
 
 
 @macromodel


### PR DESCRIPTION
Using a query mol does not find all bond angles or torsional angles, but using FIndAllPathsOfLength does.